### PR TITLE
Feature/flattening headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 VERBOSE=true
 ALLOW_GLOBAL=true
+FLATTEN_HEADERS=true
 RETURN_TYPE=html
 
 ENDPOINT=https://cloud.appwrite.io/v1

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ At the bottom of the file right after the `telegraf` service, and, right before 
 
 ```yaml
   funcover:
-    image: boolcode/appwrite-funcover:0.0.1
+    image: boolcode/appwrite-funcover:0.0.3
     container_name: funcover
     restart: unless-stopped
     environment:

--- a/README.md
+++ b/README.md
@@ -220,6 +220,30 @@ When sets to `true` Funcover will produce more logs at runtime.
 
 When sets to `true` Funcover will handle all of your function by project id.
 
+#### `FLATTEN_HEADERS`
+
+When sets to `true` Funcover will insert all of the request headers as `headers` property inside your function payload.
+
+Like so:
+```json
+{
+  "data": {
+    "data": {},
+    "headers": {}
+  }
+}
+```
+
+Notice your `data` will be sent recursively inside `data.data` property, and you'll to extract the data like so:
+```javascript
+    // First, Get the payload.
+    const payload = JSON.parse(req.payload);
+
+    // Second, parse the data and the headers.
+    const data    = JSON.parse(payload.data);
+    const headers = JSON.parse(payload.headers);
+```
+
 #### `RETURN_TYPE`
 How would you like to get the function output back
 - `normal` - (Default) Just return the function output as JSON.

--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,1 @@
-docker buildx build --platform linux/amd64,linux/arm64 -t boolcode/appwrite-funcover:0.0.2  --push .
+docker buildx build --platform linux/amd64,linux/arm64 -t boolcode/appwrite-funcover:0.0.3  --push .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -656,7 +656,7 @@ services:
       - _APP_INFLUXDB_HOST
       - _APP_INFLUXDB_PORT
   funcover:
-    image: boolcode/appwrite-funcover:0.0.1
+    image: boolcode/appwrite-funcover:0.0.3
     container_name: funcover
     restart: unless-stopped
     environment:
@@ -680,7 +680,7 @@ services:
       - traefik.http.routers.funcover-https.tls=true
 
   funcover-second:
-    image: boolcode/appwrite-funcover:0.0.1
+    image: boolcode/appwrite-funcover:0.0.3
     container_name: funcover-second
     restart: unless-stopped
     environment:

--- a/inc/lib.ts
+++ b/inc/lib.ts
@@ -1,6 +1,6 @@
 async function runFunction(projectId: string, functionId: string, c: any) {
     const data     = await getData(c);
-    const headers  = await getHeaders(c, projectId);
+    const headers  = await getHeaders(projectId);
     const verbose  = process.env.VERBOSE === 'true';
     const endpoint = process.env.ENDPOINT ?? 'http://appwrite/v1';
 
@@ -37,17 +37,12 @@ async function response(res: Response, c: any) {
     }
 }
 
-async function getHeaders(c: any, projectId: string) {
-    const headers = c.req.headers.toJSON();
+async function getHeaders(projectId: string) {
+    return {
+        'content-type'      : 'application/json',
+        'x-appwrite-project': projectId,
+    }
 
-    headers['Content-Type']       = 'application/json';
-    headers['x-appwrite-project'] = projectId
-
-    delete headers['content-type'];
-    delete headers['accept-encoding'];
-    delete headers['host'];
-
-    return headers;
 }
 
 async function getData(c: any) {
@@ -78,6 +73,16 @@ async function getData(c: any) {
         data['data'] = 'no_data';
     }
 
+    if (process.env.FLATTEN_HEADERS === 'true') {
+        return {
+            data: JSON.stringify({
+                data   : data.data,
+                headers: JSON.stringify(c.req.headers.toJSON()),
+
+            })
+        }
+    }
+
     return data;
 }
 
@@ -88,5 +93,6 @@ function getRawOrAll(data: any) {
 
     return JSON.stringify(data);
 }
+
 
 export {runFunction}


### PR DESCRIPTION
Adding option to pass header inside the Appwrite function `payload`.
There's a need for that because even it you pass `headers` they won't be passed by Appwrite Executor to the targeted runtime.